### PR TITLE
add excons submodule and SCons build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,9 +37,9 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
-+*.dblite
-+excons.cache
-Add a comment to this line
-+.build
-+release
-+debug
+
+*.dblite
+excons.cache
+/.build/
+/release/
+/debug/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "excons"]
+	path = excons
+	url = git://github.com/gatgui/excons

--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,36 @@
+import excons
+import sys
+import glob
+import excons.tools.maya as maya
+
+
+platname = {"win32": "windows", "darwin": "osx"}.get(sys.platform, "linux")
+
+outprefix = "platforms/%s/%s/%s/plug-ins" % (maya.Version(nice=True), platname, excons.arch_dir)
+
+defines = []
+if sys.platform == "win32":
+   defines.append("NOMINMAX")
+
+targets = [
+   {
+      "name": "mgear_solvers",
+      "type": "dynamicmodule",
+      "prefix": outprefix,
+      "bldprefix": maya.Version(),
+      "ext": maya.PluginExt(),
+      "defs": defines,
+      "incdirs": ["src"],
+      "srcs": glob.glob("src/*.cpp"),
+      "custom": [maya.Require],
+      "install": {"scripts": glob.glob("scripts/*"),
+                  "": ["mGear.mod"]}
+   }
+]
+
+maya.SetupMscver()
+
+env = excons.MakeBaseEnv()
+
+excons.DeclareTargets(env, targets)
+

--- a/buildAll
+++ b/buildAll
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+scons -j8 with-maya=2014
+scons -j8 with-maya=2015
+scons -j8 with-maya=2016 with-mayadevkit=/usr/autodesk/maya2016/devkitBase
+

--- a/buildAll.bat
+++ b/buildAll.bat
@@ -1,0 +1,6 @@
+@echo off
+
+scons with-maya=2014
+scons with-maya=2015
+scons with-maya=2016 with-mayadevkit="C:/Program Files/Autodesk/Maya2016/devkitBase"
+


### PR DESCRIPTION
Add SCons based build scripts.
You'll need to have [Python](https://www.python.org/) installed with [SCons](http://scons.org/).
Then in a terminal, supposing maya is installed your OS standard location, just type
```
scons with-maya=2014
```
Starting maya 2016, the development kit is a separate installation. If you decided to put it somewhere else than where it used to be prior to 2016, you may want to use the "with-mayadevkit=" flag:
```
scons with-maya=2016 with-mayadevkit=path/to/maya/devkit
```
I also suggest to use scons builtin flag -j<n> to make the most of your processors core when compiling. So on an 8 logical core machine:
```
scons -j8 with-maya=2015
```
The last scons call non built-in flags are saved and restore on next scons call unless explicitely overriden. So that running 'scons' after the last example will re-use 'with-maya=2015' automatically.