### PR TITLE
Feature/support multiple component dir

### DIFF
--- a/scripts/mgear/maya/shifter/__init__.py
+++ b/scripts/mgear/maya/shifter/__init__.py
@@ -290,8 +290,7 @@ class Rig(object):
             guide = self.guides[comp]
             mgear.log("Init : "+ guide.fullName + " ("+guide.type+")")
 
-            module_name = "mgear.maya.shifter.component."+guide.type
-            module = __import__(module_name, globals(), locals(), ["*"], -1)
+            module = importComponent(guide.type)
             Component = getattr(module , "Component")
 
             component = Component(self, guide)

--- a/scripts/mgear/maya/shifter/__init__.py
+++ b/scripts/mgear/maya/shifter/__init__.py
@@ -90,6 +90,16 @@ def gatherComponentsDirectory():
             if not os.path.exists(path):
                 continue
 
+            init_py_path = os.path.join(path, "__init__.py")
+            if not os.path.exists(init_py_path):
+                message = "= GEAR RIG SYSTEM ====== notify:"
+                message += "\n  __init__.py for custom component not found {}".format(init_py_path)
+                message += "\n\n check your module definition file or environment variable 'MGEAR_COMPONENTS_PATH'"
+                message += " or call your system administrator."
+                message += "\n"
+                mgear.log(message, mgear.sev_error)
+                continue
+
             comps = sorted(os.listdir(path))
 
             results[path] = comps
@@ -109,7 +119,9 @@ def getComponentBasePath(comp_type):
             break
     else:
         compbasepath = ""
-        mgear.log("component base directory not found for {}".format(comp_type), mgear.sev_error)
+        message = "= GEAR RIG SYSTEM ======"
+        message += "component base directory not found for {}".format(comp_type)
+        mgear.log(message, mgear.sev_error)
 
     return compbasepath
 

--- a/scripts/mgear/maya/shifter/__init__.py
+++ b/scripts/mgear/maya/shifter/__init__.py
@@ -33,6 +33,7 @@ Shifter base rig class.
 # GLOBAL
 #############################################
 # Built in
+import os.path
 import datetime
 import getpass
 
@@ -59,6 +60,86 @@ if not pm.pluginInfo("mgear_solvers", q=True, l=True):
         pm.displayError("You need the mgear_solvers plugin!")
 if not pm.pluginInfo("matrixNodes", q=True, l=True):
     pm.loadPlugin("matrixNodes")
+
+
+COMPONENT_PATH = os.path.join(os.path.dirname(__file__), "component")
+TEMPLATE_PATH = os.path.join(COMPONENT_PATH, "templates")
+SYNOPTIC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "synoptic","tabs"))
+
+
+def gatherComponentsDirectory():
+        """
+        returns component directory
+
+        Returns:
+            Dict{string: []string}
+            Component base directory
+            Compon
+        """
+
+        results = {}
+
+        # default path
+        path = os.path.join(os.path.dirname(__file__), "component")
+        comps = sorted(os.listdir(path))
+        results[path] = comps
+
+        # from environment variables
+        envvarval = os.environ.get("MGEAR_COMPONENTS_PATH", "")
+        for path in envvarval.split(';'):
+            if not os.path.exists(path):
+                continue
+
+            comps = sorted(os.listdir(path))
+
+            results[path] = comps
+
+        return results
+
+
+COMPONENTS_DIRECTORIES = gatherComponentsDirectory()
+
+
+def getComponentBasePath(comp_type):
+    # search component path
+    import mgear.maya.shifter as shifter
+    for basepath, comps in shifter.COMPONENTS_DIRECTORIES.iteritems():
+        if comp_type in comps:
+            compbasepath = os.path.basename(basepath)
+            break
+    else:
+        compbasepath = ""
+        mgear.log("component base directory not found for {}".format(comp_type), mgear.sev_error)
+
+    return compbasepath
+
+
+def importComponentGuide(comp_type):
+    compbasepath = getComponentBasePath(comp_type)
+    # Import module and get class
+    try:
+        module_name = "mgear.maya.shifter.component.{}.guide".format(comp_type)
+        module = __import__(module_name, globals(), locals(), ["*"], -1)
+
+    except ImportError:
+        module_name = "{}.{}.guide".format(compbasepath, comp_type)
+        module = __import__(module_name, globals(), locals(), ["*"], -1)
+
+    return module
+
+
+def importComponent(comp_type):
+    compbasepath = getComponentBasePath(comp_type)
+    # Import module and get class
+    try:
+        module_name = "mgear.maya.shifter.component.{}".format(comp_type)
+        module = __import__(module_name, globals(), locals(), ["*"], -1)
+
+    except ImportError:
+        module_name = "{}.{}".format(compbasepath, comp_type)
+        module = __import__(module_name, globals(), locals(), ["*"], -1)
+
+    return module
 
 
 ##########################################################
@@ -472,4 +553,3 @@ class Rig(object):
             self.components[comp_name].ui = pm.UIHost(self.components[comp_name].root)
 
         return self.components[comp_name].ui
-

--- a/scripts/mgear/maya/shifter/gui.py
+++ b/scripts/mgear/maya/shifter/gui.py
@@ -116,12 +116,7 @@ class Guide_UI(object):
                     continue
 
                 # module = __import__("mgear.maya.rig.component."+comp_name, globals(), locals(), ["*"], -1)
-                try:
-                    module = __import__("mgear.maya.shifter.component."+comp_name+".guide", globals(), locals(), ["*"], -1)
-                except ImportError:
-                    # compbasepath = re.split("[\\\/]", path)[-1]
-                    compbasepath = os.path.basename(path)
-                    module = __import__("{}.{}.guide".format(compbasepath, comp_name), globals(), locals(), ["*"], -1)
+                module = shifter.importComponent(comp_name)
                 reload(module)
                 image = os.path.join(path, comp_name, "icon.jpg")
 

--- a/scripts/mgear/maya/shifter/gui.py
+++ b/scripts/mgear/maya/shifter/gui.py
@@ -116,7 +116,7 @@ class Guide_UI(object):
                     continue
 
                 # module = __import__("mgear.maya.rig.component."+comp_name, globals(), locals(), ["*"], -1)
-                module = shifter.importComponent(comp_name)
+                module = shifter.importComponentGuide(comp_name)
                 reload(module)
                 image = os.path.join(path, comp_name, "icon.jpg")
 

--- a/scripts/mgear/maya/shifter/gui.py
+++ b/scripts/mgear/maya/shifter/gui.py
@@ -53,10 +53,6 @@ import mgear.maya.shifter.component as comp
 GUIDE_UI_WINDOW_NAME = "guide_UI_window"
 GUIDE_DOCK_NAME = "Guide_Components"
 
-COMPONENT_PATH = os.path.join(os.path.dirname(__file__), "component")
-TEMPLATE_PATH = os.path.join(COMPONENT_PATH, "templates")
-SYNOPTIC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "synoptic","tabs"))
-
 # VERSION = 2.0
 
 
@@ -109,29 +105,37 @@ class Guide_UI(object):
         pm.separator()
 
         # List of components
-        
-        path = os.path.dirname(comp.__file__)
-        for comp_name in sorted(os.listdir(path)):
+        doGrouping = 1 < len(shifter.COMPONENTS_DIRECTORIES.keys())
+        for path, comps in shifter.COMPONENTS_DIRECTORIES.iteritems():
 
-            if not os.path.exists(os.path.join(path, comp_name, "__init__.py")):
-                continue
+            pm.text(align="center", label=os.path.basename(path))
+            pm.separator()
+            for comp_name in comps:
 
-            # module = __import__("mgear.maya.rig.component."+comp_name, globals(), locals(), ["*"], -1)
-            module = __import__("mgear.maya.shifter.component."+comp_name+".guide", globals(), locals(), ["*"], -1)
-            reload(module)
-            image = os.path.join(path, comp_name, "icon.jpg")
+                if not os.path.exists(os.path.join(path, comp_name, "__init__.py")):
+                    continue
 
-            buttonSize = 25
-            textDesc = "Name: "+module.NAME+"\nType:: "+module.TYPE+"\n===========\nAuthor: "+module.AUTHOR+"\nWeb: "+module.URL+\
+                # module = __import__("mgear.maya.rig.component."+comp_name, globals(), locals(), ["*"], -1)
+                try:
+                    module = __import__("mgear.maya.shifter.component."+comp_name+".guide", globals(), locals(), ["*"], -1)
+                except ImportError:
+                    # compbasepath = re.split("[\\\/]", path)[-1]
+                    compbasepath = os.path.basename(path)
+                    module = __import__("{}.{}.guide".format(compbasepath, comp_name), globals(), locals(), ["*"], -1)
+                reload(module)
+                image = os.path.join(path, comp_name, "icon.jpg")
+
+                buttonSize = 25
+                textDesc = "Name: "+module.NAME+"\nType:: "+module.TYPE+"\n===========\nAuthor: "+module.AUTHOR+"\nWeb: "+module.URL+\
                         "\nEmail: "+module.EMAIL+"\n===========\nDescription:\n"+module.DESCRIPTION
 
-            row = pm.rowLayout(numberOfColumns=2, columnWidth=([1, buttonSize]), adjustableColumn=2, columnAttach=([1, "both", 0], [2, "both", 5]))
-            pm.symbolButton(ann=textDesc, width=buttonSize, height=buttonSize, bgc=[0,0,0], ebg=False, i=image, command=partial(self.drawComp, module.TYPE))
-            textColumn = pm.columnLayout(columnAlign="center")
-            pm.text(align="center", width=panelWeight*.6, label=module.TYPE, ann=textDesc, fn="plainLabelFont")
+                row = pm.rowLayout(numberOfColumns=2, columnWidth=([1, buttonSize]), adjustableColumn=2, columnAttach=([1, "both", 0], [2, "both", 5]))
+                pm.symbolButton(ann=textDesc, width=buttonSize, height=buttonSize, bgc=[0,0,0], ebg=False, i=image, command=partial(self.drawComp, module.TYPE))
+                textColumn = pm.columnLayout(columnAlign="center")
+                pm.text(align="center", width=panelWeight*.6, label=module.TYPE, ann=textDesc, fn="plainLabelFont")
 
-            pm.setParent(self.ui_compList_column)
-            pm.separator()
+                pm.setParent(self.ui_compList_column)
+                pm.separator()
 
         # Display the window
         pm.tabLayout(self.ui_tabs, edit=True, tabLabelIndex=([1, "Components"]))
@@ -178,7 +182,7 @@ class Guide_UI(object):
 
         comp_type = False
         guide_root = False
-        while root:            
+        while root:
             if pm.attributeQuery("comp_type", node=root, ex=True):
                 comp_type = root.attr("comp_type").get()
                 break
@@ -188,11 +192,10 @@ class Guide_UI(object):
             root = root.getParent()
             pm.select(root)
 
-            
+ 
         if comp_type:
             # try:
-            module_name = "mgear.maya.shifter.component."+comp_type+".guide"
-            guide = __import__(module_name, globals(), locals(), ["*"], -1)
+            guide = shifter.importComponentGuide(comp_type)
             gqt.showDialog(guide.componentSettings)
 
             # except:

--- a/scripts/mgear/maya/shifter/guide.py
+++ b/scripts/mgear/maya/shifter/guide.py
@@ -66,11 +66,6 @@ import customStepUI as csui
 GUIDE_UI_WINDOW_NAME = "guide_UI_window"
 GUIDE_DOCK_NAME = "Guide_Components"
 
-COMPONENT_PATH = os.path.join(os.path.dirname(__file__), "component")
-TEMPLATE_PATH = os.path.join(COMPONENT_PATH, "templates")
-SYNOPTIC_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "synoptic","tabs"))
-
-
 TYPE = "mgear_guide_root"
 
 ##########################################################
@@ -482,15 +477,18 @@ class RigGuide(MainGuide):
         """
 
         # Check component type
-        path = os.path.join(COMPONENT_PATH, comp_type, "guide.py")
+        '''
+        path = os.path.join(basepath, comp_type, "guide.py")
         if not os.path.exists(path):
             mgear.log("Can't find guide definition for : " + comp_type + ".\n"+ path, mgear.sev_error)
             return False
+        '''
 
         # Import module and get class
-        module_name = "mgear.maya.shifter.component."+comp_type+".guide"
-        module = __import__(module_name, globals(), locals(), ["*"], -1)
-        ComponentGuide = getattr(module , "Guide")
+        import mgear.maya.shifter as shifter
+        module = shifter.importComponentGuide(comp_type)
+
+        ComponentGuide = getattr(module, "Guide")
 
         return ComponentGuide()
 
@@ -1021,9 +1019,10 @@ class guideSettings(MayaQWidgetDockableMixin, QtWidgets.QDialog, helperSlots):
 
     def populateAvailableSynopticTabs(self):
 
+        import mgear.maya.shifter as shifter
         defPath = os.environ.get("MGEAR_SYNOPTIC_PATH", None)
         if not defPath or not os.path.isdir(defPath):
-            defPath = SYNOPTIC_PATH
+            defPath = shifter.SYNOPTIC_PATH
 
         tabsDirectories = [ name for name in os.listdir(defPath) if os.path.isdir(os.path.join(defPath, name)) ]
         # Quick clean the first empty item

--- a/scripts/mgear/maya/utils.py
+++ b/scripts/mgear/maya/utils.py
@@ -31,8 +31,7 @@ Utilitie functions.
 # GLOBAL
 ##########################################################
 import os
-import itertools
-import traceback
+import mgear
 
 
 ##########################################################

--- a/scripts/mgear/maya/utils.py
+++ b/scripts/mgear/maya/utils.py
@@ -30,6 +30,9 @@ Utilitie functions.
 ##########################################################
 # GLOBAL
 ##########################################################
+import os
+import itertools
+import traceback
 
 
 ##########################################################
@@ -47,3 +50,95 @@ def is_odd(num):
         bool: True or False
     """
     return num % 2
+
+
+def gatherCustomModuleDirectories(envvarkey, defaultModulePath):
+    """
+    returns component directory
+
+    Arguments:
+        envvarkey: The environment variable key name, that is searched
+        defaultModulePath: The default module path for search in.
+
+    Returns:
+        Dict{string: []string}
+    """
+
+    results = {}
+
+    # default path
+    if not os.path.exists(defaultModulePath):
+        message = "= GEAR RIG SYSTEM ====== notify:"
+        message += "\n  default module directory is not found at {}".format(defaultModulePath)
+        message += "\n\n check your mGear installation"
+        message += " or call your system administrator."
+        message += "\n"
+        mgear.log(message, mgear.sev_error)
+        return {}
+
+    modules = sorted(os.listdir(defaultModulePath))
+    results[defaultModulePath] = modules
+
+    # from environment variables
+    envvarval = os.environ.get(envvarkey, "")
+    for path in envvarval.split(os.pathsep):
+
+        if not path or not os.path.exists(path):
+            continue
+
+        init_py_path = os.path.join(path, "__init__.py")
+        if not os.path.exists(init_py_path):
+            message = "= GEAR RIG SYSTEM ====== notify:"
+            message += "\n  __init__.py for custom component not found {}".format(init_py_path)
+            message += "\n\n check your module definition file or environment variable 'MGEAR_COMPONENTS_PATH'"
+            message += " or call your system administrator."
+            message += "\n"
+            mgear.log(message, mgear.sev_error)
+            continue
+
+        modules = sorted(os.listdir(path))
+        modules = [x for x in modules if os.path.isdir(os.path.join(path, x))]
+
+        results[path] = modules
+
+    return results
+
+
+def getModuleBasePath(directories, moduleName):
+    # search component path
+    for basepath, modules in directories.iteritems():
+        if moduleName in modules:
+            moduleBasePath = os.path.basename(basepath)
+            break
+    else:
+        moduleBasePath = ""
+        message = "= GEAR RIG SYSTEM ======"
+        message += "component base directory not found for {}".format(moduleName)
+        mgear.log(message, mgear.sev_error)
+
+    return moduleBasePath
+
+
+def importFromStandardOrCustomDirectories(directories, defaultFormatter, customFormatter, moduleName):
+    """
+    return imported module
+
+    Arguments:
+        directories: the directories for search in. this is got by gatherCustomModuleDirectories
+        defaultFormatter: this represents module structure for default module. for example "mgear.maya.shifter.component.{}"
+        customFormatter:  this represents module structure for custom module. for example "{0}.{1}"
+
+    Returns:
+        module: imported module
+    """
+    # Import module and get class
+    try:
+        module_name = defaultFormatter.format(moduleName)
+        module = __import__(module_name, globals(), locals(), ["*"], -1)
+
+    except ImportError:
+        moduleBasePath = getModuleBasePath(directories, moduleName)
+        module_name = customFormatter.format(moduleBasePath, moduleName)
+        module = __import__(module_name, globals(), locals(), ["*"], -1)
+
+    return module


### PR DESCRIPTION
Hi Miquel,
This is a spike for splitting shifter component modules. Registering directories to the environment variable `MGEAR_COMPONENTS_PATH`, display and use together with the modules below the default module directory "mgear.maya.shifter.component". However, it has the following restrictions.

* Environment variables `PYTHONPATH` must be passed to additional module paths.
* From the perspective of `PYTHONPATH`, only one level of depth is allowed. 
* The folder name that stores modules must be unique(container module name)

for example
```may.env
PYTHONPATH +:= python
MGEAR_COMPONENTS_PATH +:= python/wonder_project_J_component
MGEAR_COMPONENTS_PATH +:= python/great_project_A_component
```

cheers,