### PR TITLE
fix extraction of namespace when its nested

### DIFF
--- a/scripts/mgear/maya/synoptic/tabs/biped_body/__init__.py
+++ b/scripts/mgear/maya/synoptic/tabs/biped_body/__init__.py
@@ -85,8 +85,8 @@ class SynopticTab(QtWidgets.QDialog, wui.Ui_biped_body):
         nameSpace = False
         if sels:
             oModel = syn_uti.getModel(self)
-            if  len(oModel.split(":")) == 2:
-                nameSpace = oModel.split(":")[0]
+            if  len(oModel.split(":")) >= 2:
+                nameSpace = ":".join(oModel.split(":")[:-1])
 
         selButtons = self.findChildren(mwi.SelectButton)
         for selB in selButtons:

--- a/scripts/mgear/maya/synoptic/utils.py
+++ b/scripts/mgear/maya/synoptic/utils.py
@@ -96,8 +96,8 @@ def selectObj(model, object_names, mouse_button, key_modifier):
     with pm.UndoChunk():
         nodes = []
         for name in object_names:
-            if  len(model.split(":")) == 2:
-                node = pm.PyNode( model.split(":")[0] + ":" + name)
+            if  len(model.split(":")) >= 2:
+                node = pm.PyNode(":".join(model.split(":")[:-1]) + ":" + name)
             else:
                 node = pm.PyNode(name)
             if not node and len(model.split(":")) == 2:


### PR DESCRIPTION
Hi miquel,

This pull request fixes the selection of model in multiple namespaces on synoptic. In the current implementation only one namespace is allowed. I made it possible two or more of this. Either of the following two examples will work.

```
CHAR_A_Facial:rig
CHAR_A_ALL:CHAR_A_Facial:rig
```

cheers,
Takayoshi