### PR TITLE
Fix/dont stop selecting nonexist element on synoptic

### DIFF
--- a/scripts/mgear/maya/synoptic/__init__.py
+++ b/scripts/mgear/maya/synoptic/__init__.py
@@ -127,10 +127,20 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
 
     # Singal Methods =============================
     def updateModelList(self):
+        # avoiding unnecessory firing currentIndexChanged event before finish to model_list
+        try:
+            self.model_list.currentIndexChanged.disconnect()
+        except RuntimeError:
+            pass
+
         rig_models = [item for item in pm.ls(transforms=True) if item.hasAttr("is_rig")]
         self.model_list.clear()
         for item in rig_models:
-            self.model_list.addItem(item.name(), item.name() )
+            self.model_list.addItem(item.name(), item.name())
+
+        # restore event and update tabs for reflecting self.model_list
+        self.model_list.currentIndexChanged.connect(self.updateTabs)
+        self.updateTabs()
 
     def updateTabs(self):
         self.tabs.clear()

--- a/scripts/mgear/maya/synoptic/__init__.py
+++ b/scripts/mgear/maya/synoptic/__init__.py
@@ -146,7 +146,12 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         self.tabs.clear()
         defPath = os.environ.get("MGEAR_SYNOPTIC_PATH", None)
 
-        tab_names = pm.ls(self.model_list.currentText())[0].getAttr("synoptic").split(",")
+        currentModelName = self.model_list.currentText()
+        currentModels = pm.ls(currentModelName)
+        if not currentModels:
+            return
+
+        tab_names = currentModels[0].getAttr("synoptic").split(",")
 
         for i, tab_name in enumerate(tab_names):
             try:

--- a/scripts/mgear/maya/synoptic/utils.py
+++ b/scripts/mgear/maya/synoptic/utils.py
@@ -97,6 +97,13 @@ def getNamespace(modelName):
 def stripNamespace(nodeName):
     return nodeName.split(":")[-1]
 
+def getNode(nodeName):
+    try:
+        return pm.PyNode(nodeName)
+
+    except pm.MayaNodeError:
+        return None
+
 ##################################################
 # SELECT
 ##################################################
@@ -109,9 +116,12 @@ def selectObj(model, object_names, mouse_button, key_modifier):
         for name in object_names:
             nameSpace = getNamespace(model)
             if  nameSpace:
-                node = pm.PyNode(nameSpace + ":" + name)
+                node = getNode(nameSpace + ":" + name)
             else:
-                node = pm.PyNode(name)
+                node = getNode(name)
+
+            if not node:
+                continue
 
             if not node and nameSpace:
                 mgear.log("Can't find object : %s:%s"%( nameSpace, name), mgear.sev_error)
@@ -251,14 +261,13 @@ def getComboKeys(model, object_name, combo_attr):
 
     nameSpace = getNamespace(model)
     if  nameSpace:
-        node = pm.PyNode( nameSpace + ":" + object_name)
+        node = getNode(nameSpace + ":" + object_name)
         # node = dag.findRelative(model, model.split(":")[0] + ":" + object_name)
     else:
-        node = pm.PyNode( object_name)
+        node = getNode(object_name)
         # node = dag.findRelative(model, object_name)
 
-
-    oAttr =  node.attr(combo_attr)
+    oAttr = node.attr(combo_attr)
     keys = oAttr.getEnums().keys()
     keys.append("++ Space Transfer ++")
     return keys
@@ -267,9 +276,9 @@ def getComboIndex(model, object_name, combo_attr):
 
     nameSpace = getNamespace(model)
     if  nameSpace:
-        node = pm.PyNode( nameSpace + ":" + object_name)
+        node = getNode(nameSpace + ":" + object_name)
     else:
-        node = pm.PyNode(object_name)
+        node = getNode(object_name)
 
     oVal =  node.attr(combo_attr).get()
     return oVal
@@ -278,11 +287,11 @@ def changeSpace(model, object_name, combo_attr, cnsIndex, ctl_name):
 
     nameSpace = getNamespace(model)
     if  nameSpace:
-        node = pm.PyNode( nameSpace + ":" + object_name)
-        ctl = pm.PyNode( nameSpace + ":" + ctl_name)
+        node = getNode( nameSpace + ":" + object_name)
+        ctl = getNode( nameSpace + ":" + ctl_name)
     else:
-        node = pm.PyNode(object_name)
-        ctl = pm.PyNode(ctl_name)
+        node = getNode(object_name)
+        ctl = getNode(ctl_name)
 
     sWM = ctl.getMatrix(worldSpace=True)
 
@@ -300,34 +309,34 @@ def changeSpace(model, object_name, combo_attr, cnsIndex, ctl_name):
 
     nameSpace = getNamespace(model)
 
-    uiNode = pm.PyNode(nameSpace + uiHost_name)
-    fk0 = pm.PyNode(nameSpace + fk0)
-    fk1 = pm.PyNode(nameSpace + fk1)
-    fk2 = pm.PyNode(nameSpace + fk2)
-    ik = pm.PyNode(nameSpace + ik)
-    upv = pm.PyNode(nameSpace + upv)
+    uiNode = getNode(nameSpace + uiHost_name)
+    fk0 = getNode(nameSpace + fk0)
+    fk1 = getNode(nameSpace + fk1)
+    fk2 = getNode(nameSpace + fk2)
+    ik = getNode(nameSpace + ik)
+    upv = getNode(nameSpace + upv)
     if ikRot:
-        ikRot = pm.PyNode(nameSpace + ikRot)
+        ikRot = getNode(nameSpace + ikRot)
 
     tmpName = fk0.split("_")
     tmpName[-1]="mth"
-    fk0Target = pm.PyNode("_".join(tmpName))
+    fk0Target = getNode("_".join(tmpName))
     tmpName = fk1.split("_")
     tmpName[-1]="mth"
-    fk1Target = pm.PyNode("_".join(tmpName))
+    fk1Target = getNode("_".join(tmpName))
     tmpName = fk2.split("_")
     tmpName[-1]="mth"
-    fk2Target = pm.PyNode("_".join(tmpName))
+    fk2Target = getNode("_".join(tmpName))
     tmpName = ik.split("_")
     tmpName[-1]="mth"
-    ikTarget = pm.PyNode("_".join(tmpName))
+    ikTarget = getNode("_".join(tmpName))
     tmpName = upv.split("_")
     tmpName[-1]="mth"
-    upvTarget = pm.PyNode("_".join(tmpName))
+    upvTarget = getNode("_".join(tmpName))
     if ikRot:
         tmpName = ikRot.split("_")
         tmpName[-1]="mth"
-        ikRotTarget = pm.PyNode("_".join(tmpName))
+        ikRotTarget = getNode("_".join(tmpName))
 
 
 
@@ -377,7 +386,7 @@ def mirrorPose(flip=False, nodes=False):
                     nameTarget = nameSpace +":"+ nameParts
                 else:
                     nameTarget = nameParts
-                oTarget = pm.PyNode(nameTarget)
+                oTarget = getNode(nameTarget)
                 for a in axis:
                     if not oSel.attr(a).isLocked():
                         if oSel.attr(aDic[a]).get():
@@ -456,7 +465,7 @@ def mirrorPoseOld(flip=False, nodes=False):
                     nameTarget = nameSpace+":"+"_".join(nameParts)
                 else:
                     nameTarget = "_".join(nameParts)
-                oTarget = pm.PyNode(nameTarget)
+                oTarget = getNode(nameTarget)
                 for a in axis:
                     if not oSel.attr(a).isLocked():
                         if oSel.attr(aDic[a]).get():
@@ -599,7 +608,7 @@ class spaceTransferUI(QtWidgets.QDialog):
 
 
 
-        self.ctl_node = pm.PyNode(ctrlName)
+        self.ctl_node = getNode(ctrlName)
         startFrame = self.startFrame_value.value()
         endFrame = self.endFrame_value.value()
 


### PR DESCRIPTION
This PR suppresses errors when selecting synoptic elements that does not exist in a scene. I think that this PR may conflict with the previous one( #25 ) when if you try to merge both PR,  soI will close this and send pull request again later  if you need.