### PR TITLE
Fix/leak of synoptic selectionchanged scriptjob

### DIFF
--- a/scripts/mgear/maya/synoptic/__init__.py
+++ b/scripts/mgear/maya/synoptic/__init__.py
@@ -29,14 +29,15 @@
 ##################################################
 import os
 
-import maya.cmds as cmds
-import maya.OpenMayaUI as mui
+# import maya.OpenMayaUI as mui
 import pymel.core as pm
 
 from maya.app.general.mayaMixin import MayaQDockWidget
 from maya.app.general.mayaMixin import MayaQWidgetDockableMixin
 import mgear.maya.pyqt as gqt
 import mgear.maya.utils
+
+
 QtGui, QtCore, QtWidgets, wrapInstance = gqt.qt_import()
 
 
@@ -45,8 +46,9 @@ SYNOPTIC_WIDGET_NAME = "synoptic_view"
 SYNOPTIC_ENV_KEY = "MGEAR_SYNOPTIC_PATH"
 
 SYNOPTIC_DIRECTORIES = mgear.maya.utils.gatherCustomModuleDirectories(
-            SYNOPTIC_ENV_KEY,
-            os.path.join(os.path.dirname(__file__), "tabs"))
+    SYNOPTIC_ENV_KEY,
+    os.path.join(os.path.dirname(__file__), "tabs"))
+
 
 ##################################################
 # OPEN
@@ -80,43 +82,7 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
     def create_widgets(self):
-
-        # Widgets
-        self.model_list = QtWidgets.QComboBox()
-        self.model_list.setObjectName("model_list")
-        self.refresh_button = QtWidgets.QPushButton("Refresh")
-        self.refresh_button.setObjectName("refresh_button")
-        self.tabs = QtWidgets.QTabWidget()
-        self.tabs.setObjectName("synoptic_tab")
-
-        # Layout
-        self.setObjectName(SYNOPTIC_WIDGET_NAME)
-
-        self.vbox = QtWidgets.QVBoxLayout(self)
-        self.hbox = QtWidgets.QHBoxLayout(self)
-
-        self.vbox.addLayout(self.hbox)
-        self.hbox.addWidget(self.model_list)
-        self.hbox.addWidget(self.refresh_button)
-
-        #Container Widget
-        self.scrollWidget = QtWidgets.QWidget()
-        self.scrollWidget.setFixedHeight(1024)
-        self.scrollWidget.setFixedWidth(375)
-        #Layout of Container Widget
-        self.scrollLayout = QtWidgets.QVBoxLayout(self)
-        self.scrollLayout.addWidget(self.tabs)
-        self.scrollWidget.setLayout(self.scrollLayout)
-
-        #Scroll Area Properties
-        self.scroll = QtWidgets.QScrollArea()
-        self.scroll.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
-        self.scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
-        self.scroll.setWidget(self.scrollWidget)
-
-        #Scroll Area Layer add
-        self.vbox.addWidget(self.scroll)
-        # self.setLayout(self.vbox)
+        self.setupUi()
 
         # Connect Signal
         self.refresh_button.clicked.connect(self.updateModelList)
@@ -125,6 +91,89 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         # Initialise
         self.updateModelList()
         self.updateTabs()
+
+    def setupUi(self):
+        # Widgets
+        self.setObjectName(SYNOPTIC_WIDGET_NAME)
+        self.resize(560, 775)
+
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred)
+        sizePolicy.setHorizontalStretch(1)
+        sizePolicy.setVerticalStretch(1)
+        sizePolicy.setHeightForWidth(self.sizePolicy().hasHeightForWidth())
+        self.setSizePolicy(sizePolicy)
+        self.setMinimumSize(QtCore.QSize(0, 0))
+
+        self.gridLayout_2 = QtWidgets.QGridLayout(self)
+        self.gridLayout_2.setContentsMargins(0, 0, 0, 0)
+        self.gridLayout_2.setObjectName("gridLayout_2")
+
+        self.mainContainer = QtWidgets.QGroupBox(self)
+
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred)
+        sizePolicy.setHorizontalStretch(1)
+        sizePolicy.setVerticalStretch(1)
+        sizePolicy.setHeightForWidth(self.mainContainer.sizePolicy().hasHeightForWidth())
+
+        self.mainContainer.setSizePolicy(sizePolicy)
+        self.mainContainer.setMinimumSize(QtCore.QSize(0, 0))
+        self.mainContainer.setObjectName("mainContainer")
+
+        self.gridLayout_3 = QtWidgets.QGridLayout(self.mainContainer)
+        self.gridLayout_3.setContentsMargins(0, 0, 0, 0)
+        self.gridLayout_3.setObjectName("gridLayout_3")
+
+        # header boxies
+        self.hbox = QtWidgets.QHBoxLayout()
+        self.hbox.setContentsMargins(5, 5, 5, 5)
+        self.hbox.setObjectName("hbox")
+
+        self.model_list = QtWidgets.QComboBox(self.mainContainer)
+        self.model_list.setObjectName("model_list")
+        self.model_list.setMinimumSize(QtCore.QSize(0, 23))
+
+        self.refresh_button = QtWidgets.QPushButton(self.mainContainer)
+        self.refresh_button.setObjectName("refresh_button")
+        self.refresh_button.setText("Refresh")
+
+        self.hbox.addWidget(self.model_list)
+        self.hbox.addWidget(self.refresh_button)
+        self.gridLayout_3.addLayout(self.hbox, 0, 0, 1, 1)
+
+        # synoptic main area
+        self.gridLayout = QtWidgets.QGridLayout()
+        self.gridLayout.setObjectName("gridLayout")
+        self.scrollArea = QtWidgets.QScrollArea(self.mainContainer)
+
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        sizePolicy.setHorizontalStretch(1)
+        sizePolicy.setVerticalStretch(1)
+        sizePolicy.setHeightForWidth(self.scrollArea.sizePolicy().hasHeightForWidth())
+
+        self.scrollArea.setSizePolicy(sizePolicy)
+        self.scrollArea.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.scrollArea.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
+        self.scrollArea.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollArea.setAlignment(QtCore.Qt.AlignCenter)
+        self.scrollArea.setObjectName("scrollArea")
+
+        self.tabs = QtWidgets.QTabWidget()
+        self.tabs.setSizePolicy(sizePolicy)
+        self.tabs.setObjectName("tabs")
+
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        sizePolicy.setHorizontalStretch(1)
+        sizePolicy.setVerticalStretch(1)
+        sizePolicy.setHeightForWidth(self.tabs.sizePolicy().hasHeightForWidth())
+
+        self.tabs.setSizePolicy(sizePolicy)
+        self.tabs.setObjectName("synoptic_tab")
+        self.scrollArea.setWidget(self.tabs)
+
+        self.gridLayout.addWidget(self.scrollArea, 0, 0, 1, 1)
+        self.gridLayout_3.addLayout(self.gridLayout, 2, 0, 1, 1)
+        self.gridLayout_2.addWidget(self.mainContainer, 0, 0, 1, 1)
 
     # Singal Methods =============================
     def updateModelList(self):
@@ -135,7 +184,7 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
 
     def updateTabs(self):
         self.tabs.clear()
-        defPath = os.environ.get("MGEAR_SYNOPTIC_PATH", None)
+        # defPath = os.environ.get("MGEAR_SYNOPTIC_PATH", None)
 
         tab_names = pm.ls(self.model_list.currentText())[0].getAttr("synoptic").split(",")
 
@@ -143,13 +192,134 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
             try:
                 if tab_name:
                     module = importTab(tab_name)
-                    SynopticTab = getattr(module , "SynopticTab")
+                    SynopticTab = getattr(module, "SynopticTab")
 
-                    tab = SynopticTab()
+                    tab = self.wrapTabContents(SynopticTab())
                     self.tabs.insertTab(i, tab, tab_name)
                 else:
-                    pm.displayWarning("No synoptic tabs for %s"%self.model_list.currentText())
-            except:
+                    mes = "No synoptic tabs for %s" % self.model_list.currentText()
+                    pm.displayWarning(mes)
+
+            except Exception as e:
                 import traceback
                 traceback.print_exc()
-                pm.displayError("Synoptic tab: %s Loading fail"%tab_name)
+                mes = "Synoptic tab: %s Loading fail {0}\n{1}".format(tab_name, e)
+                pm.displayError(mes)
+
+    def wrapTabContents(self, synoptic_tab):
+        # type: (SynopticTab) -> QtWidgets.QWidget
+
+        # horizontal layout:
+        #     spacer >>  SynopticTab << spacer
+
+        if synoptic_tab.minimumHeight() == 0:
+            synoptic_tab.setMinimumHeight(synoptic_tab.height())
+
+        if synoptic_tab.minimumWidth() == 0:
+            synoptic_tab.setMinimumWidth(synoptic_tab.width())
+
+        wrapperWidget = SynopticTabWrapper()
+        wrapperWidget.setGeometry(QtCore.QRect(0, 0, 10, 10))
+        wrapperWidget.setObjectName("wrapperWidget")
+
+        horizontalLayout = QtWidgets.QHBoxLayout(wrapperWidget)
+        horizontalLayout.setContentsMargins(0, 0, 0, 0)
+        horizontalLayout.setObjectName("horizontalLayout")
+
+        spacer_left = QtWidgets.QSpacerItem(0, 0, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        spacer_right = QtWidgets.QSpacerItem(0, 0, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
+        # spacer_left.setObjectName("spacer_left")
+        # spacer_right.setObjectName("spacer_right")
+        wrapperWidget.setSpacerLeft(spacer_left)
+
+        horizontalLayout.addItem(spacer_left)
+        horizontalLayout.addWidget(synoptic_tab)
+        horizontalLayout.addItem(spacer_right)
+
+        horizontalLayout.setStretch(0, 1)
+        horizontalLayout.setStretch(1, 0)
+        horizontalLayout.setStretch(2, 1)
+
+        return wrapperWidget
+
+
+class SynopticTabWrapper(QtWidgets.QWidget):
+    """
+    class for handling mouse rubberband within spacer and synoptic tab that is children of.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(SynopticTabWrapper, self).__init__(*args, **kwargs)
+
+        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.rubberband = QtWidgets.QRubberBand(QtWidgets.QRubberBand.Rectangle, self)
+        self.offset = QtCore.QPoint()
+
+    def setSpacerLeft(self, spacer):
+        self.spacer = spacer
+
+    def searchMainSynopticTab(self):
+        # type: () -> MainSynopticTab
+
+        # avoiding cyclic import, declaration here not top of code
+        from mgear.maya.synoptic.tabs import MainSynopticTab
+        for kid in self.children():
+            if isinstance(kid, MainSynopticTab):
+                return kid
+
+            if "SynopticTab" in str(type(kid)):
+                return kid
+
+        else:
+            mes = "synoptic tab not found"
+            mgear.log(mes, mgear.sev_warn)
+            return None
+
+    def calculateOffset(self):
+        # type: () -> QtCore.QPoint
+
+        w = self.spacer.geometry().width()
+        return QtCore.QPoint(w * -1, 0)
+
+    def offsetEvent(self, event):
+        # type: (QtGui.QMouseEvent) -> QtGui.QMouseEvent
+
+        offsetev = QtGui.QMouseEvent(
+            QtCore.QEvent.MouseButtonPress,
+            event.pos() + self.offset,
+            event.globalPos(),
+            event.button(),
+            event.buttons(),
+            event.modifiers()
+        )
+
+        return offsetev
+
+    def mousePressEvent(self, event):
+        # type: (QtGui.QMouseEvent) -> None
+
+        self.syn_widget = self.searchMainSynopticTab()
+        self.offset = self.calculateOffset()
+        self.origin = event.pos()
+
+        self.rubberband.setGeometry(QtCore.QRect(self.origin, QtCore.QSize()))
+        self.rubberband.show()
+
+        self.syn_widget.mousePressEvent(self.offsetEvent(event))
+
+    def mouseMoveEvent(self, event):
+        # type: (QtGui.QMouseEvent) -> None
+
+        if self.rubberband.isVisible():
+            self.rubberband.setGeometry(QtCore.QRect(self.origin, event.pos()).normalized())
+
+        self.syn_widget.mouseMoveEvent(self.offsetEvent(event))
+
+    def mouseReleaseEvent(self, event):
+        # type: (QtGui.QMouseEvent) -> None
+
+        if self.rubberband.isVisible():
+            self.rubberband.hide()
+            self.syn_widget.mouseReleaseEvent(self.offsetEvent(event))
+
+        self.offset = QtCore.QPoint()

--- a/scripts/mgear/maya/synoptic/__init__.py
+++ b/scripts/mgear/maya/synoptic/__init__.py
@@ -77,6 +77,7 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         gqt.deleteInstances(self, MayaQDockWidget)
         super(Synoptic, self).__init__(parent)
         self.create_widgets()
+        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
 
     def create_widgets(self):
 

--- a/scripts/mgear/maya/synoptic/__init__.py
+++ b/scripts/mgear/maya/synoptic/__init__.py
@@ -285,7 +285,7 @@ class SynopticTabWrapper(QtWidgets.QWidget):
         # type: (QtGui.QMouseEvent) -> QtGui.QMouseEvent
 
         offsetev = QtGui.QMouseEvent(
-            QtCore.QEvent.MouseButtonPress,
+            event.type(),
             event.pos() + self.offset,
             event.globalPos(),
             event.button(),
@@ -305,7 +305,7 @@ class SynopticTabWrapper(QtWidgets.QWidget):
         self.rubberband.setGeometry(QtCore.QRect(self.origin, QtCore.QSize()))
         self.rubberband.show()
 
-        self.syn_widget.mousePressEvent(self.offsetEvent(event))
+        self.syn_widget.mousePressEvent_(self.offsetEvent(event))
 
     def mouseMoveEvent(self, event):
         # type: (QtGui.QMouseEvent) -> None
@@ -313,11 +313,11 @@ class SynopticTabWrapper(QtWidgets.QWidget):
         if self.rubberband.isVisible():
             self.rubberband.setGeometry(QtCore.QRect(self.origin, event.pos()).normalized())
 
-        self.syn_widget.mouseMoveEvent(self.offsetEvent(event))
+        self.syn_widget.mouseMoveEvent_(self.offsetEvent(event))
 
     def mouseReleaseEvent(self, event):
         # type: (QtGui.QMouseEvent) -> None
 
         if self.rubberband.isVisible():
             self.rubberband.hide()
-            self.syn_widget.mouseReleaseEvent(self.offsetEvent(event))
+            self.syn_widget.mouseReleaseEvent_(self.offsetEvent(event))

--- a/scripts/mgear/maya/synoptic/__init__.py
+++ b/scripts/mgear/maya/synoptic/__init__.py
@@ -155,7 +155,7 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         sizePolicy.setHeightForWidth(self.scrollArea.sizePolicy().hasHeightForWidth())
 
         self.scrollArea.setSizePolicy(sizePolicy)
-        self.scrollArea.setFocusPolicy(QtCore.Qt.NoFocus)
+        self.scrollArea.setFrameShape(QtWidgets.QFrame.NoFrame)
         self.scrollArea.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
         self.scrollArea.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
         self.scrollArea.setWidgetResizable(True)

--- a/scripts/mgear/maya/synoptic/__init__.py
+++ b/scripts/mgear/maya/synoptic/__init__.py
@@ -321,5 +321,3 @@ class SynopticTabWrapper(QtWidgets.QWidget):
         if self.rubberband.isVisible():
             self.rubberband.hide()
             self.syn_widget.mouseReleaseEvent(self.offsetEvent(event))
-
-        self.offset = QtCore.QPoint()

--- a/scripts/mgear/maya/synoptic/tabs/__init__.py
+++ b/scripts/mgear/maya/synoptic/tabs/__init__.py
@@ -174,18 +174,18 @@ class MainSynopticTab(QtWidgets.QDialog):
                 else:
                     selB.paintSelected(False)
 
-    def mousePressEvent(self, event):
+    def mousePressEvent_(self, event):
         # type: (QtGui.QMouseEvent) -> None
 
         self.origin = event.pos()
         QtWidgets.QWidget.mousePressEvent(self, event)
 
-    def mouseMoveEvent(self, event):
+    def mouseMoveEvent_(self, event):
         # type: (QtGui.QMouseEvent) -> None
 
         QtWidgets.QWidget.mouseMoveEvent(self, event)
 
-    def mouseReleaseEvent(self, event):
+    def mouseReleaseEvent_(self, event):
         # type: (QtGui.QMouseEvent) -> None
 
         if not self.origin:

--- a/scripts/mgear/maya/synoptic/tabs/__init__.py
+++ b/scripts/mgear/maya/synoptic/tabs/__init__.py
@@ -118,8 +118,6 @@ class MainSynopticTab(QtWidgets.QDialog):
         # self.b_keyAll.clicked.connect(self.keyAll_clicked)
         # self.b_keySel.clicked.connect(self.keySel_clicked)
 
-        self.rubberband = QtWidgets.QRubberBand(QtWidgets.QRubberBand.Rectangle, self)
-
     def connectMaya(self):
         # type: () -> None
         # script job callback
@@ -177,55 +175,60 @@ class MainSynopticTab(QtWidgets.QDialog):
                     selB.paintSelected(False)
 
     def mousePressEvent(self, event):
+        # type: (QtGui.QMouseEvent) -> None
+
         self.origin = event.pos()
-        self.rubberband.setGeometry(QtCore.QRect(self.origin, QtCore.QSize()))
-        self.rubberband.show()
         QtWidgets.QWidget.mousePressEvent(self, event)
 
     def mouseMoveEvent(self, event):
-        if self.rubberband.isVisible():
-            self.rubberband.setGeometry(QtCore.QRect(self.origin, event.pos()).normalized())
+        # type: (QtGui.QMouseEvent) -> None
+
         QtWidgets.QWidget.mouseMoveEvent(self, event)
 
     def mouseReleaseEvent(self, event):
-        if self.rubberband.isVisible():
-            self.rubberband.hide()
-            selected = []
-            rect = self.rubberband.geometry()
+        # type: (QtGui.QMouseEvent) -> None
 
-            for child in self.findChildren(mwi.SelectButton):
-                if rect.intersects(child.geometry()):
-                    selected.append(child)
+        selected = []
+        rect = QtCore.QRect(self.origin, event.pos())
 
-            if selected:
-                firstLoop = True
-                with pm.UndoChunk():
-                    for wi in selected:
-                        wi.rectangleSelection(event, firstLoop)
-                        firstLoop = False
+        for child in self.findChildren(mwi.SelectButton):
+            if rect.intersects(child.geometry()):
+                selected.append(child)
 
-            else:
-                if event.modifiers() == QtCore.Qt.NoModifier:
-                    pm.select(cl=True)
-                    pm.displayInfo("Clear selection")
+        if selected:
+            firstLoop = True
+            with pm.UndoChunk():
+                for wi in selected:
+                    wi.rectangleSelection(event, firstLoop)
+                    firstLoop = False
+
+        else:
+            if event.modifiers() == QtCore.Qt.NoModifier:
+                pm.select(cl=True)
+                pm.displayInfo("Clear selection")
 
         QtWidgets.QWidget.mouseReleaseEvent(self, event)
 
     # ============================================
     # BUTTONS
     def selAll_clicked(self):
+        # type: () -> None
         model = syn_uti.getModel(self)
         syn_uti.selAll(model)
 
     def resetAll_clicked(self):
+        # type: () -> None
         print "resetAll"
 
     def resetSel_clicked(self):
+        # type: () -> None
         print "resetSel"
 
     def keyAll_clicked(self):
+        # type: () -> None
         model = syn_uti.getModel(self)
         syn_uti.keyAll(model)
 
     def keySel_clicked(self):
+        # type: () -> None
         syn_uti.keySel()

--- a/scripts/mgear/maya/synoptic/tabs/__init__.py
+++ b/scripts/mgear/maya/synoptic/tabs/__init__.py
@@ -23,3 +23,209 @@
 # Author:     Jeremie Passerin      geerem@hotmail.com  www.jeremiepasserin.com
 # Author:     Miquel Campos         hello@miquel-campos.com  www.miquel-campos.com
 # Date:       2016 / 10 / 10
+
+
+##################################################
+# GLOBAL
+##################################################
+import traceback
+
+import pymel.core as pm
+import maya.OpenMayaUI as OpenMayaUI
+import mgear.maya.pyqt as gqt
+
+import mgear
+import mgear.maya.synoptic.utils as syn_uti
+import mgear.maya.synoptic.widgets as mwi
+
+# import functools
+
+QtGui, QtCore, QtWidgets, wrapInstance, shiboken = gqt.qt_import(True)
+
+
+##################################################
+# SYNOPTIC TAB WIDGET
+##################################################
+class MainSynopticTab(QtWidgets.QDialog):
+    """
+    Base class of synoptic tab widget
+
+    """
+
+    description = "base calss of synoptic tab"
+    name = ""
+    bgPath = None
+
+    buttons = []
+    default_buttons = [
+        {"name": "selAll", "mouseTracking": True},
+        {"name": "keyAll"},
+        {"name": "keySel"},
+        {"name": "resetAll"},
+        {"name": "resetSel"}
+    ]
+
+    # ============================================
+    # INIT
+    def __init__(self, klass, parent=None):
+        # type: (MainSynopticTab, QtWidgets.QWidget) -> None
+
+        print("Loading synoptic tab of {0}".format(self.name))
+
+        super(MainSynopticTab, self).__init__(parent)
+
+        klass.setupUi(self)
+        klass.setBackground()
+        klass.connectSignals()
+        klass.connectMaya()
+
+        # This is necessary for not to be zombie job on close.
+        # Qt does not actually destroy the object by just pressing
+        # close button by default.
+        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+
+    def setBackground(self):
+        # type: () -> None
+
+        # Retarget background Image to absolute path
+        if self.bgPath is not None:
+            self.img_background.setPixmap(QtGui.QPixmap(self.bgPath))
+
+    def connectSignals(self):
+        # type: () -> None
+
+        def _conn(entry):
+            name = entry.get("name")
+            buttonName = "b_{0}".format(name)
+            button = getattr(self, buttonName, None)
+
+            clickEventName = "{0}_clicked".format(name)
+            clickEvent = getattr(self, clickEventName, None)
+
+            if not button or not clickEvent:
+                return  # TODO
+
+            button.clicked.connect(clickEvent)
+            if entry.get("mouseTracking", False):
+                button.setMouseTracking(True)
+
+        # this is equivalent to below code commented out
+        for entry in self.default_buttons + self.buttons:
+            _conn(entry)
+
+        # self.b_selAll.clicked.connect(self.selAll_clicked)
+        # self.b_selAll.setMouseTracking(True)
+        # self.b_keyAll.clicked.connect(self.keyAll_clicked)
+        # self.b_keySel.clicked.connect(self.keySel_clicked)
+
+        self.rubberband = QtWidgets.QRubberBand(QtWidgets.QRubberBand.Rectangle, self)
+
+    def connectMaya(self):
+        # type: () -> None
+        # script job callback
+        ptr = long(shiboken.getCppPointer(self)[0])
+        gui = OpenMayaUI.MQtUtil.fullName(ptr)
+        self.selJob = pm.scriptJob(e=("SelectionChanged", self.selectChanged), parent=gui)
+
+    def selectChanged(self, *args):
+        """
+
+        :param args:
+        """
+
+        # wrap to catch exception guaranteeing maya does not stop at this
+        try:
+            self.__selectChanged(*args)
+
+        except Exception as e:
+            mes = traceback.format_exc()
+            mes = "error has occur in scriptJob SelectionChanged\n{0}".format(mes)
+            mes = "{0}\n{1}".format(mes, e)
+            mgear.log(mes, mgear.sev_error)
+
+    def __selectChanged(self, *args):
+
+        sels = []
+        [sels.append(x.name()) for x in pm.ls(sl=True)]
+
+        oModel = syn_uti.getModel(self)
+        if not oModel:
+            mes = "model not found for synoptic"
+            mgear.log(mes, mgear.sev_info)
+
+            self.close()
+
+            syn_widget = syn_uti.getSynopticWidget(self)
+            syn_widget.updateModelList()
+
+            return
+
+        nameSpace = syn_uti.getNamespace(oModel.name())
+
+        selButtons = self.findChildren(mwi.SelectButton)
+        for selB in selButtons:
+            obj = str(selB.property("object")).split(",")
+            if len(obj) == 1:
+                if nameSpace:
+                    checkName = ":".join([nameSpace, obj[0]])
+                else:
+                    checkName = obj[0]
+
+                if checkName in sels:
+                    selB.paintSelected(True)
+                else:
+                    selB.paintSelected(False)
+
+    def mousePressEvent(self, event):
+        self.origin = event.pos()
+        self.rubberband.setGeometry(QtCore.QRect(self.origin, QtCore.QSize()))
+        self.rubberband.show()
+        QtWidgets.QWidget.mousePressEvent(self, event)
+
+    def mouseMoveEvent(self, event):
+        if self.rubberband.isVisible():
+            self.rubberband.setGeometry(QtCore.QRect(self.origin, event.pos()).normalized())
+        QtWidgets.QWidget.mouseMoveEvent(self, event)
+
+    def mouseReleaseEvent(self, event):
+        if self.rubberband.isVisible():
+            self.rubberband.hide()
+            selected = []
+            rect = self.rubberband.geometry()
+
+            for child in self.findChildren(mwi.SelectButton):
+                if rect.intersects(child.geometry()):
+                    selected.append(child)
+
+            if selected:
+                firstLoop = True
+                with pm.UndoChunk():
+                    for wi in selected:
+                        wi.rectangleSelection(event, firstLoop)
+                        firstLoop = False
+
+            else:
+                if event.modifiers() == QtCore.Qt.NoModifier:
+                    pm.select(cl=True)
+                    pm.displayInfo("Clear selection")
+
+        QtWidgets.QWidget.mouseReleaseEvent(self, event)
+
+    # ============================================
+    # BUTTONS
+    def selAll_clicked(self):
+        model = syn_uti.getModel(self)
+        syn_uti.selAll(model)
+
+    def resetAll_clicked(self):
+        print "resetAll"
+
+    def resetSel_clicked(self):
+        print "resetSel"
+
+    def keyAll_clicked(self):
+        model = syn_uti.getModel(self)
+        syn_uti.keyAll(model)
+
+    def keySel_clicked(self):
+        syn_uti.keySel()

--- a/scripts/mgear/maya/synoptic/tabs/__init__.py
+++ b/scripts/mgear/maya/synoptic/tabs/__init__.py
@@ -188,9 +188,11 @@ class MainSynopticTab(QtWidgets.QDialog):
     def mouseReleaseEvent(self, event):
         # type: (QtGui.QMouseEvent) -> None
 
-        selected = []
-        rect = QtCore.QRect(self.origin, event.pos())
+        if not self.origin:
+            self.origin = event.pos()
 
+        selected = []
+        rect = QtCore.QRect(self.origin, event.pos()).normalized()
         for child in self.findChildren(mwi.SelectButton):
             if rect.intersects(child.geometry()):
                 selected.append(child)
@@ -207,6 +209,7 @@ class MainSynopticTab(QtWidgets.QDialog):
                 pm.select(cl=True)
                 pm.displayInfo("Clear selection")
 
+        self.origin = None
         QtWidgets.QWidget.mouseReleaseEvent(self, event)
 
     # ============================================

--- a/scripts/mgear/maya/synoptic/tabs/biped_body/__init__.py
+++ b/scripts/mgear/maya/synoptic/tabs/biped_body/__init__.py
@@ -28,126 +28,26 @@
 # GLOBAL
 ##################################################
 import os
-import pymel.core as pm
-import maya.OpenMayaUI as OpenMayaUI
 import mgear.maya.pyqt as gqt
-QtGui, QtCore, QtWidgets, wrapInstance, shiboken = gqt.qt_import(True)
 
-
-import xml.etree.ElementTree as xml
-from cStringIO import StringIO
-
-import mgear.maya.synoptic.utils as syn_uti
-import mgear.maya.synoptic.widgets as mwi
+from mgear.maya.synoptic.tabs import MainSynopticTab
 import widget as wui
 
-import functools
-
-BG_PATH = os.path.join(os.path.dirname(__file__), "background.bmp")
+QtGui, QtCore, QtWidgets, wrapInstance, shiboken = gqt.qt_import(True)
 
 
 ##################################################
 # SYNOPTIC TAB WIDGET
 ##################################################
 
-class SynopticTab(QtWidgets.QDialog, wui.Ui_biped_body):
+
+class SynopticTab(MainSynopticTab, wui.Ui_biped_body):
+
+    description = "biped body"
+    name = "biped_body"
+    bgPath = os.path.join(os.path.dirname(__file__), "background.bmp")
 
     # ============================================
     # INIT
     def __init__(self, parent=None):
-        super(SynopticTab, self).__init__(parent)
-        print "Loading body"
-        self.setupUi(self)
-
-        # Retarget background Image to absolute path
-        self.img_background.setPixmap(QtGui.QPixmap(BG_PATH))
-
-        # Connect signal
-        self.b_selAll.clicked.connect(self.selAll_clicked)
-        self.b_selAll.setMouseTracking(True)
-        self.b_keyAll.clicked.connect(self.keyAll_clicked)
-        self.b_keySel.clicked.connect(self.keySel_clicked)
-
-        self.rubberband = QtWidgets.QRubberBand(QtWidgets.QRubberBand.Rectangle, self)
-
-        #script job callback
-        ptr = long(shiboken.getCppPointer(self)[0])
-        gui = OpenMayaUI.MQtUtil.fullName(ptr)
-        self.selJob = pm.scriptJob(e=("SelectionChanged", self.selectChanged), parent=gui)
-    
-    def selectChanged(self, *args):
-        """
-
-        :param args:
-        """
-        sels = []
-        [sels.append(x.name()) for x in  pm.ls(sl=1)]
-        nameSpace = False
-        if sels:
-            oModel = syn_uti.getModel(self)
-            if  len(oModel.split(":")) >= 2:
-                nameSpace = ":".join(oModel.split(":")[:-1])
-
-        selButtons = self.findChildren(mwi.SelectButton)
-        for selB in selButtons:
-            obj = str(selB.property("object")).split(",")
-            if len(obj) == 1:
-                if nameSpace:
-                    checkName = nameSpace+":"+obj[0]
-                else: 
-                    checkName = obj[0]
-                if checkName in sels:
-                    selB.paintSelected(True)
-                else:
-                    selB.paintSelected(False)
-
-    def mousePressEvent(self, event):
-        self.origin = event.pos()
-        self.rubberband.setGeometry(QtCore.QRect(self.origin, QtCore.QSize()))
-        self.rubberband.show()
-        QtWidgets.QWidget.mousePressEvent(self, event)
-
-    def mouseMoveEvent(self, event):
-        if self.rubberband.isVisible():
-            self.rubberband.setGeometry(QtCore.QRect(self.origin, event.pos()).normalized())
-        QtWidgets.QWidget.mouseMoveEvent(self, event)
-
-
-    def mouseReleaseEvent(self, event):
-        if self.rubberband.isVisible():
-            self.rubberband.hide()
-            selected = []
-            rect = self.rubberband.geometry()
-            for child in self.findChildren(mwi.SelectButton):
-                if rect.intersects(child.geometry()):
-                    selected.append(child)
-            if selected:
-                firstLoop = True
-                with pm.UndoChunk():
-                    for wi in selected:
-                        wi.rectangleSelection(event,firstLoop)
-                        firstLoop = False
-            else:
-                if event.modifiers() == QtCore.Qt.NoModifier:
-                    pm.select(cl=True)
-                    pm.displayInfo("Clear selection")
-        QtWidgets.QWidget.mouseReleaseEvent(self, event)
-
-    # ============================================
-    # BUTTONS
-    def selAll_clicked(self):
-        model = syn_uti.getModel(self)
-        syn_uti.selAll(model)
-
-    def resetAll_clicked(self):
-        print "resetAll"
-
-    def resetSel_clicked(self):
-        print "resetSel"
-
-    def keyAll_clicked(self):
-        model = syn_uti.getModel(self)
-        syn_uti.keyAll(model)
-
-    def keySel_clicked(self):
-        syn_uti.keySel()
+        super(SynopticTab, self).__init__(self, parent)

--- a/scripts/mgear/maya/synoptic/tabs/biped_body/widget.py
+++ b/scripts/mgear/maya/synoptic/tabs/biped_body/widget.py
@@ -29,8 +29,8 @@ QtGui, QtCore, QtWidgets, wrapInstance = gqt.qt_import()
 class Ui_biped_body(object):
     def setupUi(self, biped_body):
         biped_body.setObjectName("biped_body")
-        biped_body.resize(375, 840)
-        biped_body.setMinimumSize(QtCore.QSize(375, 0))
+        biped_body.resize(325, 840)
+        biped_body.setMinimumSize(QtCore.QSize(325, 790))
         self.b_selD = QuickSelButton(biped_body)
         self.b_selD.setGeometry(QtCore.QRect(10, 740, 31, 31))
         palette = QtGui.QPalette()

--- a/scripts/mgear/maya/synoptic/tabs/biped_body/widget.ui
+++ b/scripts/mgear/maya/synoptic/tabs/biped_body/widget.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>375</width>
+    <width>325</width>
     <height>840</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>375</width>
-    <height>0</height>
+    <width>325</width>
+    <height>790</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/scripts/mgear/maya/synoptic/tabs/biped_hands/__init__.py
+++ b/scripts/mgear/maya/synoptic/tabs/biped_hands/__init__.py
@@ -28,72 +28,37 @@
 # GLOBAL
 ##################################################
 import os
-
 import mgear.maya.pyqt as gqt
-QtGui, QtCore, QtWidgets, wrapInstance = gqt.qt_import()
-import xml.etree.ElementTree as xml
-from cStringIO import StringIO
 
 import mgear.maya.synoptic.utils as syn_uti
-import mgear.maya.synoptic.widgets as mwi
+from mgear.maya.synoptic.tabs import MainSynopticTab
 import widget as wui
 
+QtGui, QtCore, QtWidgets, wrapInstance, shiboken = gqt.qt_import(True)
 
-
-
-BG_PATH = os.path.join(os.path.dirname(__file__), "background.bmp")
 
 ##################################################
 # SYNOPTIC TAB WIDGET
 ##################################################
 
-class SynopticTab(QtWidgets.QDialog, wui.Ui_biped_hand):
+
+class SynopticTab(MainSynopticTab, wui.Ui_biped_hand):
+
+    description = "biped body"
+    name = "biped_body"
+    bgPath = os.path.join(os.path.dirname(__file__), "background.bmp")
+
+    buttons = [
+        {"name": "selRight"},
+        {"name": "selLeft"},
+        {"name": "keyRight"},
+        {"name": "keyLeft"},
+    ]
 
     # ============================================
     # INIT
     def __init__(self, parent=None):
-        super(SynopticTab, self).__init__(parent)
-        self.setupUi(self)
-
-        # Retarget background Image to absolute path
-        self.img_background.setPixmap(QtGui.QPixmap(BG_PATH))
-
-        # Connect signal
-        self.b_selRight.clicked.connect(self.selRight_clicked)
-        self.b_selLeft.clicked.connect(self.selLeft_clicked)
-        self.b_keyRight.clicked.connect(self.keyRight_clicked)
-        self.b_keyLeft.clicked.connect(self.keyLeft_clicked)
-        self.b_keySel.clicked.connect(self.keySel_clicked)
-
-        self.rubberband = QtWidgets.QRubberBand(QtWidgets.QRubberBand.Rectangle, self)
-
-    def mousePressEvent(self, event):
-        self.origin = event.pos()
-        self.rubberband.setGeometry(QtCore.QRect(self.origin, QtCore.QSize()))
-        self.rubberband.show()
-        QtWidgets.QWidget.mousePressEvent(self, event)
-
-    def mouseMoveEvent(self, event):
-        if self.rubberband.isVisible():
-            self.rubberband.setGeometry(QtCore.QRect(self.origin, event.pos()).normalized())
-        QtWidgets.QWidget.mouseMoveEvent(self, event)
-
-    def mouseReleaseEvent(self, event):
-        if self.rubberband.isVisible():
-            self.rubberband.hide()
-            selected = []
-            rect = self.rubberband.geometry()
-            for child in self.findChildren(mwi.SelectButton):
-                if rect.intersects(child.geometry()):
-                    selected.append(child)
-            if selected:
-                firstLoop = True
-                for wi in selected:
-                    wi.rectangleSelection(event,firstLoop)
-                    firstLoop = False
-            else:
-                print ' Nothing Selected\n'
-        QtWidgets.QWidget.mouseReleaseEvent(self, event)
+        super(SynopticTab, self).__init__(self, parent)
 
     # ============================================
     # BUTTONS
@@ -128,6 +93,3 @@ class SynopticTab(QtWidgets.QDialog, wui.Ui_biped_hand):
         thumb_names = ["thumb_L0_fk%s_ctl"%j for j in range(3)]
         object_names.extend(thumb_names)
         syn_uti.keyObj(model, object_names)
-
-    def keySel_clicked(self):
-        syn_uti.keySel()

--- a/scripts/mgear/maya/synoptic/tabs/biped_hands/widget.py
+++ b/scripts/mgear/maya/synoptic/tabs/biped_hands/widget.py
@@ -30,7 +30,7 @@ QtGui, QtCore, QtWidgets, wrapInstance = gqt.qt_import()
 class Ui_biped_hand(object):
     def setupUi(self, biped_hand):
         biped_hand.setObjectName("biped_hand")
-        biped_hand.resize(879, 790)
+        biped_hand.resize(325, 330)
         self.b_selD = QuickSelButton(biped_hand)
         self.b_selD.setGeometry(QtCore.QRect(219, 287, 31, 31))
         palette = QtGui.QPalette()

--- a/scripts/mgear/maya/synoptic/tabs/biped_hands/widget.ui
+++ b/scripts/mgear/maya/synoptic/tabs/biped_hands/widget.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>879</width>
-    <height>790</height>
+    <width>325</width>
+    <height>330</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Form</string>

--- a/scripts/mgear/maya/synoptic/utils.py
+++ b/scripts/mgear/maya/synoptic/utils.py
@@ -75,7 +75,18 @@ def getModel(widget):
 
     syn_widget = getSynopticWidget(widget, max_iter=20)
     model_name = syn_widget.model_list.currentText()
-    model = pm.PyNode(model_name)
+
+    if not pm.ls(model_name):
+        return None
+
+    try:
+        model = pm.PyNode(model_name)
+
+    except pm.general.MayaNodeError:
+        mes = traceback.format_exc()
+        mes = "Can't find model {0} for widget: {1}\n{2}".format(model_name, widget, mes)
+        mgear.log(mes, mgear.sev_error)
+        return None
 
     return model
 
@@ -87,6 +98,9 @@ def getControlers(model):
     return members
 
 def getNamespace(modelName):
+    if not modelName:
+        return ""
+
     if len(modelName.split(":")) >= 2:
         nameSpace = ":".join(modelName.split(":")[:-1])
     else:
@@ -103,11 +117,14 @@ def stripNamespace(nodeName):
 # ================================================
 def selectObj(model, object_names, mouse_button, key_modifier):
 
+    if not model:
+        return
+
+    nameSpace = getNamespace(model)
 
     with pm.UndoChunk():
         nodes = []
         for name in object_names:
-            nameSpace = getNamespace(model)
             if  nameSpace:
                 node = pm.PyNode(nameSpace + ":" + name)
             else:


### PR DESCRIPTION
This PR includes 1 fix and some improvements.

* Fix scriptJob "SelectionChanged" event leak
* Improve synoptic widget view and behaviour

---

### scriptJob event leak

#### leak

The SynopticTab class holds `self.selJob = pm.scriptJob(e=("SelectionChanged", self.selectChanged), parent=gui)` . Usually If the  parent `gui` is deleted, scriptJob also deleted ( http://help.autodesk.com/view/MAYAUL/2017/ENU/?guid=GUID-A42F2A04-0216-408D-8073-F4D4D896CE8D ). But QWidget is not deleted by default when only closing window ( http://doc.qt.io/qt-5/qwidget.html#close ). Thus the scriptJob survives against expectation.

#### error handling for callkback

Apart from avobe, scriptJob "SelectionChanged" event could cause an error when scene item especially  that is in Synoptic.model_list is changed.

#### conclusion

maya becomes very unstable by this two points.


### fix

* flag SynopticTab.setAttribute(QtCore.Qt.WA_DeleteOnClose) to immidiate destroy and kill its job
* add error handling and update the model list when model is missing in selectionChanged callback
* extract SynopticTab into MainSynopticTab


---

### improve

* auto fit scroll area to its inner synoptic content
* auto resize synoptic widget window to its content on update tabs
* align content to center 