### PR TITLE
Synoptic scriptJobs leak Revisited

### DIFF
--- a/scripts/mgear/maya/synoptic/__init__.py
+++ b/scripts/mgear/maya/synoptic/__init__.py
@@ -79,11 +79,16 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
 
     def __init__(self, parent=None):
         self.toolName = SYNOPTIC_WIDGET_NAME
+        self.script_jobs = list()
         # Delete old instances of the componet settings window.
         gqt.deleteInstances(self, MayaQDockWidget)
         super(Synoptic, self).__init__(parent)
         self.create_widgets()
         self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+
+    def closeEvent(self, event):
+        for job in self.script_jobs:
+            pm.scriptJob(kill=job)
 
     def create_widgets(self):
         self.setupUi()
@@ -199,7 +204,7 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
                 if tab_name:
                     # instantiate SynopticTab widget
                     module = importTab(tab_name)
-                    synoptic_tab = getattr(module, "SynopticTab")()
+                    synoptic_tab = getattr(module, "SynopticTab")(self)
 
                     # set minimum size for auto fit (stretch) scroll area
                     if synoptic_tab.minimumHeight() == 0:

--- a/scripts/mgear/maya/synoptic/__init__.py
+++ b/scripts/mgear/maya/synoptic/__init__.py
@@ -90,6 +90,7 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
         for job in self.script_jobs:
             pm.scriptJob(kill=job)
 
+
     def create_widgets(self):
         self.setupUi()
 

--- a/scripts/mgear/maya/synoptic/tabs/__init__.py
+++ b/scripts/mgear/maya/synoptic/tabs/__init__.py
@@ -124,6 +124,7 @@ class MainSynopticTab(QtWidgets.QDialog):
         ptr = long(shiboken.getCppPointer(self)[0])
         gui = OpenMayaUI.MQtUtil.fullName(ptr)
         self.selJob = pm.scriptJob(e=("SelectionChanged", self.selectChanged), parent=gui)
+        self.parent().script_jobs.append(self.selJob)
 
     def selectChanged(self, *args):
         """


### PR DESCRIPTION
This is a quick fix for the synoptic scriptJobs that are being left behind after closing the synoptic, that was causing other UI issues.
Tested on Maya 2016