### PR TITLE
Fix/synoptic tabs leak

### DIFF
--- a/scripts/mgear/maya/synoptic/__init__.py
+++ b/scripts/mgear/maya/synoptic/__init__.py
@@ -94,7 +94,6 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
 
         # Initialise
         self.updateModelList()
-        self.updateTabs()
 
     def setupUi(self):
         # Widgets

--- a/scripts/mgear/maya/synoptic/__init__.py
+++ b/scripts/mgear/maya/synoptic/__init__.py
@@ -197,6 +197,9 @@ class Synoptic(MayaQWidgetDockableMixin, QtWidgets.QDialog):
 
 
     def updateTabs(self):
+
+        for i in range(self.tabs.count()):
+            self.tabs.widget(i).close()
         self.tabs.clear()
         # defPath = os.environ.get("MGEAR_SYNOPTIC_PATH", None)
 


### PR DESCRIPTION
This PR fix synoptic tabs leak, related ba69f10e0f94ded9493c5b7548278f73a02d7ed0
and make getting SelectButton (under nested widget) geometry absolute coordinate when detecting intersection.

- leak
It seems that QWidgetTabtabs.clear() does not destroy python object but delete internal c++ object, on the second (or lrater) tab(s). I've tested on maya2017 update3

- SelectButton geometry
This enables to grouping buttons under QFrame.