### PR TITLE
Minor Tweaks

### DIFF
--- a/scripts/mgear/maya/primitive.py
+++ b/scripts/mgear/maya/primitive.py
@@ -307,6 +307,11 @@ def add2DChain(parent, name, positions, normal, negate=False, vis=True):
 
                 jp = jnt.getParent()
 
+                # Aviod intermediate e.g. `transform3` groups that can appear
+                # between joints due to basic moving around.
+                while jp.type() == "transform":
+                    jp = jp.getParent()
+
                 jp.setAttr("jointOrient", 0, 0, jp.attr("jointOrient").get()[2]*-1)
 
         jnt.setAttr("radius", 1.5)

--- a/scripts/mgear/maya/shifter/component/guide.py
+++ b/scripts/mgear/maya/shifter/component/guide.py
@@ -263,7 +263,9 @@ class ComponentGuide(MainGuide):
             else:
                 node = dag.findChild(self.model, self.getName(name))
                 if not node:
-                    mgear.log("Object missing : %s"%name, mgear.sev_warning)
+                    mgear.log("Object missing : %s" % (
+                        self.getName(name), mgear.sev_warning)
+                    )
                     self.valid = False
                     continue
 
@@ -276,7 +278,9 @@ class ComponentGuide(MainGuide):
 
             node = dag.findChild(self.model, self.getName(name))
             if not node:
-                mgear.log("Object missing : %s"%name, mgear.sev_warning)
+                mgear.log("Object missing : %s" % (
+                    self.getName(name), mgear.sev_warning)
+                )
                 self.valid = False
                 continue
 


### PR DESCRIPTION
Hi @miquelcampos, I ran into some issues and made a few tweaks to mGear as I went.

- `primitive.py`: This one I got when working with the `Import Biped Guide` and moving his hands. My guess is that it introduces an unsupported translation onto the joint, causing Maya to create an intermediate transform group above it to accommodate for it. This tweak takes that into account and should be entirely backwards compatible.
- `guide.py`: At some point, one of the guide controllers got renamed (still unsure of how), resulting in the build to break. As I figured out that the name was to blame, I struggled to make sense out of the error message that said `"Object missing: root"`. Next time, it'll say `"Object missing: arm_L0_root"` which is a little more descriptive.

More details in the commit messages.

I've also got a question about how you generally iterate on this project, as I discovered that the `mgear.__init__.py` is being generated during build. The only benefit I could find from doing that was to keep version numbers in sync across multiple files, but the cost is adding to the complexity of using the project as-is from GitHub, making it difficult (especially for beginners) to contribute to your project.

What are your thoughts on biting that bullet, and manually updating the version number such that this file won't need any build-time generation? I'd also suggest you take another look at using custom deformers by default, as this introduces another complication in contributing - building those plug-ins. If instead the defaults were native to Maya, then not only would installation be simplified but contribution made simpler.

Just a thought!