### PR TITLE
Repair submodule paths

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "excons"]
 	path = excons
-	url = git://github.com/gatgui/excons
+	url = https://github.com/gatgui/excons.git
 [submodule "cvwrap"]
 	path = cvwrap
-	url = git://github.com/miquelcampos/cvwrap
+	url = https://github.com/miquelcampos/cvwrap.git


### PR DESCRIPTION
This will enable cloning via `git clone https://github.com/miquelcampos/mgear.git --recursive`

Previously, this would throw an error.

```bash
$ git clone https://github.com/miquelcampos/mgear.git
...
Cloning into 'C:/Users/marcus/github/mgear/cvwrap'...
fatal: unable to connect to github.com:
github.com[0: 192.30.253.113]: errno=Invalid argument
github.com[1: 192.30.253.112]: errno=Invalid argument

fatal: clone of 'git://github.com/miquelcampos/cvwrap' into submodule path 'C:/Users/marcus/github/mgear/cvwrap' failed
```