### PR TITLE
Setup tests on Travis

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+source = scripts
+
+[report]
+include = scripts/*

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ excons.cache
 /mGear.mod
 
 
+cover/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "excons"]
 	path = excons
-	url = git://github.com/gatgui/excons
+	url = https://github.com/gatgui/excons.git
 [submodule "cvwrap"]
 	path = cvwrap
-	url = git://github.com/miquelcampos/cvwrap
+	url = https://github.com/miquelcampos/cvwrap.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: python
 
+# cvwrap is incorrectly configured to pull
+# its submodules via ssh as opposed to https
+git:
+  submodules: false
+
 python:
   - 2.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+
+python:
+  - 2.7
+
+services:
+  - docker
+
+install:
+  - docker build -t mgear .
+
+script:
+  - docker run -ti --rm -v $(pwd):/workspace mgear

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ install:
 
 script:
   - docker run -ti --rm -v $(pwd):/workspace mgear
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM mottosso/maya:2016sp1
+
+RUN wget https://bootstrap.pypa.io/get-pip.py && \
+	mayapy get-pip.py && \
+	mayapy -m pip install \
+		nose \
+		nose-exclude \
+		coverage \
+		sphinx \
+		six \
+		sphinxcontrib-napoleon \
+		python-coveralls
+
+# Avoid creation of auxilliary files
+ENV PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /workspace
+
+ENTRYPOINT mayapy -u run_tests.py

--- a/SConstruct
+++ b/SConstruct
@@ -4,12 +4,20 @@ import excons
 import excons.config
 import excons.tools.maya as maya
 
+# Assuming SConstruct is called from the current working directory
+scriptsdir = os.path.join(os.getcwd(), "scripts")
+assert os.path.isdir(scriptsdir), (
+  "SConstruct wasn't called from the mgear/ root directory"
+)
+sys.path.insert(0, scriptsdir)
+
+import mgear
 
 maya.SetupMscver()
 env = excons.MakeBaseEnv()
 
 
-version = (2, 2, 5)
+version = mgear.VERSION
 versionstr = "%d.%d.%d" % version
 platname = {"win32": "windows", "darwin": "osx"}.get(sys.platform, "linux")
 outprefix = "platforms/%s/%s/%s/plug-ins" % (maya.Version(nice=True), platname, excons.arch_dir)

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,0 +1,102 @@
+"""Use Mayapy for testing
+
+Usage:
+    $ mayapy run_tests.py
+
+"""
+
+import os
+import sys
+import nose
+import logging
+import contextlib
+
+import six
+
+from maya import standalone
+from nose_exclude import NoseExclude
+
+
+def null(*args, **kwargs):
+    pass
+
+
+@contextlib.contextmanager
+def mute():
+    try:
+        sys.stdout = six.moves.StringIO()
+        sys.stderr = six.moves.StringIO()
+        yield
+
+    finally:
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+
+
+if __name__ == "__main__":
+    # Expose mgear Python package to tests
+    dirname = os.path.dirname(__file__)
+    sys.path.insert(0, os.path.join(dirname, "scripts"))
+
+    print("Initialising Maya..")
+    with mute():
+        standalone.initialize()
+        import pymel.core
+        import pymel.internal.startup
+        pymel.internal.startup.fixMayapy2011SegFault()
+
+    for name, logger in logging.Logger.manager.loggerDict.items():
+        if "pymel" in name:
+            logger.disabled = True
+
+    argv = sys.argv[:]
+    argv.extend([
+
+        # Sometimes, files from Windows accessed
+        # from Linux cause the executable flag to be
+        # set, and Nose has an aversion to these
+        # per default.
+        "--exe",
+
+        # Produce nice, easily readable output from each test
+        "--verbose",
+
+        # Run through the docstring of every module
+        # and run anything prefixed with ">>> "
+        "--with-doctest",
+
+        # Produce a coverage report post-tests
+        "--with-coverage",
+        "--cover-html",
+        "--cover-tests",
+        "--cover-erase",
+
+        "--exclude-dir=cvwrap",
+        "--exclude-dir=docs",
+        "--exclude-dir=excons",
+        "--exclude-dir=src",
+
+        "tests",
+        "scripts",
+    ])
+
+    # Visually separate output from the above Maya initialisation
+    # and the actual tests.
+    # TODO: Mute Maya output entirely; I don't know how it manages to still
+    # output anything when sys.stdout and err are discarded..
+    print("\n" + "-" * 70)
+    print("Running tests..\n")
+
+    try:
+        # Disable messages via PyMEL, they obfuscate the report
+        pymel.core.displayWarning = null
+        pymel.core.displayError = null
+
+        nose.main(argv=argv, addplugins=[NoseExclude()])
+
+    finally:
+        # Only bother when running when on Travis
+        if os.getenv("TRAVIS_JOB_ID"):
+            __import__("coveralls").wear()
+        else:
+            sys.stdout.write("Skipping coveralls\n")

--- a/scripts/mgear/__init__.py
+++ b/scripts/mgear/__init__.py
@@ -34,7 +34,6 @@ mGear init module.
 # built-in
 import os
 import sys
-import string
 import exceptions
 
 # Debug mode for the logger
@@ -49,7 +48,7 @@ sev_verbose = 16
 sev_comment = 32
 
 # gear version
-VERSION = @MGEAR_VERSION@
+VERSION = (2, 2, 5)
 
 
 ##########################################################
@@ -60,7 +59,7 @@ def logInfos():
     """
     Log version of Gear
     """
-    print "GEAR version : "+getVersion()
+    print "GEAR version : " + getVersion()
 
 
 def getVersion():

--- a/tests/test_mgear_attribute.py
+++ b/tests/test_mgear_attribute.py
@@ -1,141 +1,62 @@
-# MGEAR is under the terms of the MIT License
-
-# Copyright (c) 2016 Jeremie Passerin, Miquel Campos
-
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
-# Author:     Jeremie Passerin      geerem@hotmail.com  www.jeremiepasserin.com
-# Author:     Miquel Campos         hello@miquel-campos.com  www.miquel-campos.com
-# Date:       2016 / 10 / 10
-
-
-import unittest
+from maya import cmds
 import pymel.core as pm
+
 import mgear.maya.attribute as att
 
-# Test suite for mgear.maya.attribute module.
-
-class attribute_moveChannel_TestCase(unittest.TestCase):
-    """Test for moveChannel function on attribute module
-    """
-    def setUp(self):
-        self.testName = self.shortDescription()
-        if (self.testName in [  "move_channel", "move_channel_index", "move_channel_fullName",
-                                "move_channel_merge", "proxy_channel"]):
-            pm.displayInfo("Running: {}".format(self.testName))
-            self.pcs = pm.polyCube(n="pCube_source")
-            self.pcs2 = pm.polyCube(n="pCube_source2")
-            self.pct = pm.polyCube(n="pCube_target")
-            self.chanName = "bla_{}".format(self.testName)
-            ch1 = att.addAttribute(self.pcs[0], self.chanName, "double", 0, minValue=0, maxValue=1 )
-            ch2 = att.addAttribute(self.pcs2[0], self.chanName, "double", 0, minValue=0, maxValue=1 )
-            pm.connectAttr(ch1, self.pcs[0].ty)
-            pm.connectAttr(ch2, self.pcs2[0].ty)
-        else:
-            pm.displayWarning("UNKNOWN TEST ROUTINE: {}".format(self.testName))
+from nose.tools import (
+    assert_false,
+    assert_is_none,
+    with_setup,
+)
 
 
-    def tearDown(self):
-        if (self.testName in [  "move_channel", "move_channel_index", "move_channel_fullName",
-                                "move_channel_merge", "proxy_channel"]):
-            pm.delete(self.pcs)
-            pm.delete(self.pcs2)
-            pm.delete(self.pct)
+def source_nodes():
+    cmds.file(new=True, force=True)
+
+    source1, _ = pm.polyCube(name="source1")
+    source2, _ = pm.polyCube(name="source2")
+    target, _ = pm.polyCube(name="target")
+
+    ch1 = att.addAttribute(source1,
+                           "chanName",
+                           "double",
+                           0,
+                           minValue=0,
+                           maxValue=1)
+    ch2 = att.addAttribute(source2,
+                           "chanName",
+                           "double",
+                           0,
+                           minValue=0,
+                           maxValue=1)
+
+    pm.connectAttr(ch1, source1.ty)
+    pm.connectAttr(ch2, source2.ty)
 
 
-    def test_moveChannel(self):
-        """move_channel
-        """
-        for s in [self.pcs[0], self.pcs2[0]]:
-            self.assertFalse(att.moveChannel(self.chanName,  s,  self.pct[0]))
+@with_setup(source_nodes)
+def test_move_channel():
+    """chanName.moveChannel works"""
 
-    def test_moveChannel_index(self):
-        """move_channel_index
-        """
-        for s in [self.pcs[0], self.pcs2[0]]:
-            self.assertIsNone(att.moveChannel(self.chanName,  s,  self.pct[0], "index"))
-
-    def test_moveChannel_fullName(self):
-        """move_channel_fullName
-        """
-        for s in [self.pcs[0], self.pcs2[0]]:
-            self.assertIsNone(att.moveChannel(self.chanName,  s,  self.pct[0], "fullName"))
-
-    def test_moveChannel_merge(self):
-        """move_channel_merge
-        """
-        for s in [self.pcs[0], self.pcs2[0]]:
-            self.assertIsNone(att.moveChannel(self.chanName,  s,  self.pct[0], "merge"))
+    for source in ("source1", "source2"):
+        assert_false(
+            att.moveChannel("chanName", source, "target")
+        )
 
 
+@with_setup(source_nodes)
+def test_moveChannel_index():
+    """move_channel_index"""
+    for source in ("source1", "source2"):
+        assert_is_none(
+            att.moveChannel("chanName", source, "source1", "index")
+        )
 
 
-class attribute_addProxyAttribute_TestCase(unittest.TestCase):
-
-
-    def setUp(self):
-        self.testName = self.shortDescription()
-        if (self.testName in ["proxy_channel", "proxy_channel_index", "proxy_channel_fullName"]):
-            pm.displayInfo("Running: {}".format(self.testName))
-            self.pcs = pm.polyCube(n="pCube_source")
-            self.pcs2 = pm.polyCube(n="pCube_source2")
-            self.pct = pm.polyCube(n="pCube_target")
-            self.chanName = "bla_{}".format(self.testName)
-            ch1 = att.addAttribute(self.pcs[0], self.chanName, "double", 0, minValue=0, maxValue=1 )
-            ch2 = att.addAttribute(self.pcs2[0], self.chanName, "double", 0, minValue=0, maxValue=1 )
-            pm.connectAttr(ch1, self.pcs[0].ty)
-            pm.connectAttr(ch2, self.pcs2[0].ty)
-        else:
-            pm.displayWarning("UNKNOWN TEST ROUTINE: {}".format(self.testName))
-
-    def tearDown(self):
-        if (self.testName in ["proxy_channel", "proxy_channel_index", "proxy_channel_fullName"]):
-            pm.delete(self.pcs)
-            pm.delete(self.pcs2)
-            pm.delete(self.pct)
-
-    def test_addProxyAttribute(self):
-        """proxy_channel
-        """
-        source = pm.PyNode("{}.{}".format(self.pcs[0], self.chanName))
-        source2 = pm.PyNode("{}.{}".format(self.pcs2[0], self.chanName))
-        self.assertIsNone(att.addProxyAttribute(source,  self.pct[0]))
-        self.assertIsNone(att.addProxyAttribute(source2,  self.pct[0]))
-
-    def test_addProxyAttribute_index(self):
-        """proxy_channel_index
-        """
-        source = pm.PyNode("{}.{}".format(self.pcs[0], self.chanName))
-        source2 = pm.PyNode("{}.{}".format(self.pcs2[0], self.chanName))
-        self.assertIsNone(att.addProxyAttribute(source,  self.pct[0], "index"))
-        self.assertIsNone(att.addProxyAttribute(source2,  self.pct[0], "index"))
-
-    def test_addProxyAttribute_fullName(self):
-        """proxy_channel_fullName
-        """
-        source = pm.PyNode("{}.{}".format(self.pcs[0], self.chanName))
-        source2 = pm.PyNode("{}.{}".format(self.pcs2[0], self.chanName))
-        self.assertIsNone(att.addProxyAttribute(source,  self.pct[0], "fullName"))
-        self.assertIsNone(att.addProxyAttribute(source2,  self.pct[0], "fullName"))
-
-
-
-
-if __name__=='__main__':
-    unittest.main(exit=False)
+@with_setup(source_nodes)
+def test_moveChannel_fullName():
+    """move_channel_fullName"""
+    for source in ("source1", "source2"):
+        assert_is_none(
+            att.moveChannel("chanName", source, "source1", "fullName")
+        )

--- a/tests/test_rigbits_channelWrangler.py
+++ b/tests/test_rigbits_channelWrangler.py
@@ -1,69 +1,53 @@
-# MGEAR is under the terms of the MIT License
-
-# Copyright (c) 2016 Jeremie Passerin, Miquel Campos
-
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
-# Author:     Jeremie Passerin      geerem@hotmail.com  www.jeremiepasserin.com
-# Author:     Miquel Campos         hello@miquel-campos.com  www.miquel-campos.com
-# Date:       2016 / 10 / 10
-
-
-import unittest
+from maya import cmds
 import pymel.core as pm
-import mgear.maya.rigbits.channelWrangler as cw
-import mgear.maya.attribute as att
+
+from mgear.maya.rigbits import channelWrangler
+from mgear.maya import attribute
+
+from nose.tools import (
+    assert_is_none,
+    with_setup,
+)
+
+self = type("self", (object,), {})
+self.config = {
+    "movePolicy": "merge",
+    "proxyPolicy": "index",
+    "map": [
+        ["shoulder_ik", "armUI_R0_ctl", "armUI_L0_ctl", 0],
+        ["shoulder_rotRef", "armUI_R0_ctl", "armUI_L0_ctl", 0],
+        ["shoulder_rotRef", "armUI_R1_ctl", "armUI_L0_ctl", 0]
+    ]
+}
 
 
-class cwTestCase(unittest.TestCase):
+def source_nodes():
+    cmds.file(new=True, force=True)
 
-    def setUp(self):
-        self.config = { "movePolicy":"merge",
-                        "proxyPolicy":"index",
-                        "map":[ ["shoulder_ik", "armUI_R0_ctl", "armUI_L0_ctl", 0],
-                                ["shoulder_rotRef", "armUI_R0_ctl", "armUI_L0_ctl", 0],
-                                ["shoulder_rotRef", "armUI_R1_ctl", "armUI_L0_ctl", 0]]}
-
-        self.pcs = pm.polyCube(n="armUI_R0_ctl")
-        self.pcs2 = pm.polyCube(n="armUI_R1_ctl")
-        self.pct = pm.polyCube(n="armUI_L0_ctl")
-        att.addAttribute(self.pcs[0], "shoulder_ik", "double", 0, minValue=0, maxValue=1 )
-        ch2 = att.addAttribute(self.pcs[0], "shoulder_rotRef", "double", 0, minValue=0, maxValue=1 )
-        ch3 = att.addAttribute(self.pcs2[0], "shoulder_rotRef", "double", 0, minValue=0, maxValue=1 )
-        pm.connectAttr(ch2, self.pcs[0].ty)
-        pm.connectAttr(ch3, self.pcs2[0].ty)
-
-
-    def tearDown(self):
-        pm.delete(self.pcs)
-        pm.delete(self.pcs2)
-        pm.delete(self.pct)
-
-    def test_applyChannelConfig(self):
-        self.assertIsNone(cw._applyChannelConfig(self.config))
-
-    # def test_applyChannelConfigFromFile(self):
-    #     filePath = ""
-    #     self.assertIsNone(cw.applyChannelConfig(filePath))
+    pcs = pm.polyCube(name="armUI_R0_ctl")
+    pcs2 = pm.polyCube(name="armUI_R1_ctl")
+    attribute.addAttribute(pcs[0],
+                           "shoulder_ik",
+                           "double",
+                           0,
+                           minValue=0,
+                           maxValue=1)
+    ch2 = attribute.addAttribute(pcs[0],
+                                 "shoulder_rotRef",
+                                 "double",
+                                 0,
+                                 minValue=0,
+                                 maxValue=1)
+    ch3 = attribute.addAttribute(pcs2[0],
+                                 "shoulder_rotRef",
+                                 "double",
+                                 0,
+                                 minValue=0,
+                                 maxValue=1)
+    pm.connectAttr(ch2, pcs[0].ty)
+    pm.connectAttr(ch3, pcs2[0].ty)
 
 
-
-
-if __name__=='__main__':
-    unittest.main(exit=False)
+@with_setup(source_nodes)
+def test_applyChannelConfig():
+    assert_is_none(channelWrangler._applyChannelConfig(self.config))


### PR DESCRIPTION
Hi Miquel,

I've established a basic test harness for use on Travis. At the moment, this will:

1. Expose Maya to Travis
2. Run tests found under `tests/`
3. Run doctests found in `scripts/`
4. Produce a coverage report (currently at 5%!)
5. Currently it will also fail on almost every test

The majority of failures come from doctests.

### How it works

Any module or function prefixed with `test_` is considered a test by [`nose`](nose.readthedocs.io). A test is a plain Python function and doesn't require subclassing or special magic like the standard library `unittest`. This makes tests easy to read and easy to write. It also makes it difficult to get fancy, like you can with pytest and friends.

Doctests works like this.

- For every module, class, method or function with a docstring
- Find any line beginning with `>>> `
- Run that line, and compare the output with that on the next line.

For example.

```python
def add(a, b):
  """Add a to b

  Example
    >>> add(5, 1)
    6

  """

  return a + b
```

This will cause `add(5, 1)` to run as an individual test, and if the result isn't `6` then the test will fail. This is really useful and I was happy to see so many doctests already in place. Unfortunately few if any of them actually work, but we can change this!

Doctests are a good replacement for a standalone test, like those under `tests/` when inputs and outputs are contained and small. They aren't good for tests that require setup or teardown, as they would modify global state and affect their surrounding doctests. Not good.

### Next

Here's what you need to do that I can't do for you.

1. Setup a user accound at [travis](travis-ci.org)
2. Register mgear with Travis

Then once this PR is merged, tests will run. Then we can have a look at setting up https://coveralls.io/ as well.

I also had to make `__init__.py.in` of `mgear` into a plain module. I get why you did it that way, but sometimes code duplication is a good thing.