### PR TITLE
Repair Scons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,23 @@ RUN wget https://bootstrap.pypa.io/get-pip.py && \
 		sphinxcontrib-napoleon \
 		python-coveralls
 
+# Support building of Maya plug-ins
+RUN yum groupinstall -y 'Development Tools' && \
+	yum install -y scons
+
+RUN git clone https://github.com/autodesk-adn/Maya-devkit.git /devkit && \
+	rm -rf /usr/autodesk/maya/devkit \
+		   /usr/autodesk/maya/mkspecs \
+		   /usr/autodesk/maya/include && \
+	ln -s /devkit/linux/devkit /usr/autodesk/maya/devkit && \
+	ln -s /devkit/linux/mkspecs /usr/autodesk/maya/mkspecs && \
+	ln -s /devkit/linux/include /usr/autodesk/maya/include
+
 # Avoid creation of auxilliary files
 ENV PYTHONDONTWRITEBYTECODE=1
 
 WORKDIR /workspace
 
-ENTRYPOINT mayapy -u run_tests.py
+ENTRYPOINT \
+	scons no-cache=1 with-maya=2016 with-mayadevkit=/usr/autodesk/maya/devkit && \
+	mayapy -u run_tests.py

--- a/SConstruct
+++ b/SConstruct
@@ -27,7 +27,6 @@ outdir = excons.OutputBaseDirectory()
 gen = excons.config.AddGenerator(env, "mgear", {"MGEAR_VERSION": "[%d, %d, %d]" % version,
                                                 "MGEAR_MAJMIN_VERSION": "%d.%d" % (version[0], version[1])})
 
-mgearinit = gen(outdir + "/scripts/mgear/__init__.py", "scripts/mgear/__init__.py.in")
 mgearmod = gen("mGear.mod", "mGear.mod.in")
 
 defines = []
@@ -56,7 +55,6 @@ targets = [
                   "scripts/mgear": filter(lambda x: not x.endswith(".py.in"), excons.glob("scripts/mgear/*")),
                   "tests": excons.glob("tests/*.py"),
                   "": mgearmod},
-      "deps": mgearinit
    },
    {
       "name": "cvwrap",
@@ -78,7 +76,7 @@ excons.AddHelpTargets(mgear="mgear maya framework")
 
 td = excons.DeclareTargets(env, targets)
 
-env.Alias("mgear", mgearinit + [td["mgear_solvers"], td["cvwrap"]])
+env.Alias("mgear", [td["mgear_solvers"], td["cvwrap"]])
 
 td["python"] = filter(lambda x: os.path.splitext(str(x))[1] != ".mel", Glob(outdir + "/scripts/*"))
 td["scripts"] = Glob(outdir + "/scripts/*.mel")

--- a/run_tests.py
+++ b/run_tests.py
@@ -38,7 +38,9 @@ if __name__ == "__main__":
     dirname = os.path.dirname(__file__)
     sys.path.insert(0, os.path.join(dirname, "scripts"))
 
+    print("\n" + "-" * 70)
     print("Initialising Maya..")
+
     with mute():
         standalone.initialize()
         import pymel.core


### PR DESCRIPTION
This restores SConstruct and also builds plug-ins on Travis.

As I put this together I realised we could have kept the previous `.in` file, and built it *before* testing it. But what I'd really like to do is separate parts that require compilation from parts that don't. All Python modules are plain Python, which is great! But the fact that they require a build in order to run makes it difficult for contributors who may not be interested in the plug-ins that are built alongside it.

We chatted about separating mgear into "modules", this is a good start to that I think.