### PR TITLE
ignore vs code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
-
+.vscode/
 
 *.py[cod]
 


### PR DESCRIPTION
Adding vscode to gitignore. Been using this as an editor more recently, setting build tasks for scons is nice.